### PR TITLE
Fix transparent-canada.ca link

### DIFF
--- a/content/community/sites.ad
+++ b/content/community/sites.ad
@@ -9,7 +9,7 @@ Jonathan Bullock
 To help others see what's possible with JBake add your JBake powered site to the list below by making a https://github.com/jbake-org/jbake.org/blob/master/content/community/sites.ad[pull request].
 
 * http://vorozco.com[Víctor Orozco's blog] (https://github.com/tuxtor/the-j[source])
-* http://http://transparent-canada.ca/[Transparent Canada]
+* http://transparent-canada.ca/ [Transparent Canada]
 * http://hyunlabs.com/[hyunlabs] (https://github.com/danhyun/blog[source])
 * http://msgilligan.github.io[Sean Gilligan's blog] (https://github.com/msgilligan/msgilligan.github.io[source])
 * http://grycman.eu [Daniel Grycman's blog (German)]


### PR DESCRIPTION
Fix transparent-canada.ca link in sites.ad file