### PR TITLE
data model index pagination

### DIFF
--- a/content/docs/2.5.1/build-tool-integration.ad
+++ b/content/docs/2.5.1/build-tool-integration.ad
@@ -1,0 +1,58 @@
+= Build Tool Integration
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Build Tool Integration
+
+=== Maven Plugin
+
+There is a http://maven.apache.org[Maven] plugin that allows you to run JBake from your Maven build.
+
+* http://docs.ingenieux.com.br/project/jbake/walkthrough.html[Plugin walkthrough]
+* https://github.com/ingenieux/jbake-maven-plugin[Plugin on GitHub]
+
+The plugin is available from the Maven Central repository using the following coordinates:
+
+[source,xml]
+----
+<dependency>
+    <groupId>br.com.ingenieux</groupId>
+    <artifactId>jbake-maven-plugin</artifactId>
+    <version>0.0.9</version>
+</dependency>
+----
+
+The plugin has been developed by https://github.com/aldrinleal[Aldrin Leal].
+
+=== Gradle Plugin
+
+There is a http://gradle.org/[Gradle] plugin that allows you to run JBake from your Gradle build.
+
+* https://plugins.gradle.org/plugin/me.champeau.jbake[Plugin Page on Gradle.org]
+* https://github.com/jbake-org/jbake-gradle-plugin[Plugin on GitHub]
+* https://bintray.com/melix/gradle-plugins/jbake-gradle-plugin/view[Plugin on Bintray]
+
+The plugin has been developed by http://melix.github.io/blog/[Cédric Champeau].
+
+=== SBuild Plugin
+
+There is a http://sbuild.org/[SBuild] plugin that allows you to run JBake from your SBuild build.
+
+* https://github.com/SBuild-org/sbuild-jbake[Plugin on GitHub]
+
+The plugin is available from the Maven Central repository using the following coordinates:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.sbuild</groupId>
+    <artifactId>org.sbuild.plugins.jbake</artifactId>
+    <version>0.1.2</version>
+</dependency>
+----
+
+The plugin has been developed by https://github.com/lefou[Tobias Roeser].

--- a/content/docs/2.5.1/configuration.ad
+++ b/content/docs/2.5.1/configuration.ad
@@ -1,0 +1,488 @@
+= Configuration
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Configuration
+
+The `jbake.properties` file (or legacy file custom.properties) allows you to customise the configuration of JBake for your project.
+For example you can change the name of the folder that stores your content or templates, decide whether to generate a 
+RSS feed or not. The following sections detail the complete list of configuration options available to you. JBake ships 
+with a default configuration file (https://github.com/jbake-org/jbake/blob/master/src/main/resources/default.properties[default.properties]) 
+that defines the defaults for these options however you can choose to override these by defining options in your `jbake.properties` file.
+
+So in the absence of these options in your jbake.properties the default value provided by JBake will be used. 
+
+You can also comment out any configuration options by adding a hash or number sign as the first character on a line in your file.
+
+=== Built in options
+
+==== Default assets directory
+
+This option defines the name of the directory that holds the assets for your project.
+
+----
+# folder that contains all asset files
+asset.folder=assets
+----
+
+==== Default content directory
+
+This option defines the name of the directory that holds the content files for your project.
+
+----
+# folder that contains all content files
+content.folder=content
+----
+
+==== Default output/destination directory
+
+This option defines the name of the directory that will be used for the baked output to be placed in.
+
+----
+# path to destination folder by default
+destination.folder=output
+----
+
+==== Default template directory
+
+This option defines the name of the directory that holds the template files for your project.
+
+----
+# folder that contains all template files
+template.folder=templates
+----
+
+==== Default index template file
+
+This option defines the default template file that will be used to render the index file
+
+----
+# filename of masterindex template file
+template.masterindex.file=index.ftl
+----
+
+WARNING: In past releases this option was known as: `template.index.file`
+
+==== Default archive template file
+
+This option defines the default template file that will be used to render an archive file
+
+----
+# filename of archive template file
+template.archive.file=archive.ftl
+----
+
+==== Default feed template file
+
+This option defines the default template file that will be used to render a feed file
+
+----
+# filename of feed template file
+template.feed.file=feed.ftl
+----
+
+==== Default sitemap template file
+
+This option defines the default template file that will be used to render a sitemap file
+
+----
+# filename of sitemap template file
+template.sitemap.file=sitemap.ftl
+----
+
+==== Default tags template file
+
+This option defines the default template file that will be used when rendering a file for each tag
+
+----
+# filename of tag template file
+template.tag.file=tags.ftl
+----
+
+==== Default page template file
+
+This option defines the default template file that will be used when rendering a file of type=page
+
+----
+# filename of page template file
+template.page.file=page.ftl
+----
+
+==== Default post template file
+
+This option defines the default template file that will be used when rendering a file of type=post
+
+----
+# filename of post template file
+template.post.file=post.ftl
+----
+
+==== Default encoding for templates
+
+This option defines the character encoding that should be used when reading in the template files
+
+----
+# character encoding MIME name used in templates.
+# use one of http://www.iana.org/assignments/character-sets/character-sets.xhtml
+template.encoding=UTF-8
+----
+
+==== Render index file
+
+This option defines whether an index file should be rendered or not
+
+----
+# render index file?
+render.index=true
+----
+
+TIP: This option is useful when you want to use a content file as your index file allowing you to define specific content for the page instead of just using
+the template.
+
+==== Render archive file
+
+This option defines whether an archive file should be rendered or not
+
+----
+# render archive file?
+render.archive=true
+----
+
+==== Render feed file
+
+This option defines whether a feed file should be rendered or not
+
+----
+# render feed file?
+render.feed=true
+----
+
+==== Render sitemap file
+
+This option defines whether a sitemap file should be rendered or not
+
+----
+# render sitemap.xml file?
+render.sitemap=false
+----
+
+==== Render tag files
+
+This option defines whether tag files are rendered or not
+
+----
+# render tag files?
+render.tags=true
+----
+
+==== Default index output filename
+
+This option defines the output filename to be used when rendering the index file
+
+----
+# filename to use for index file
+index.file=index.html
+----
+
+==== Default archive output filename
+
+This option defines the output filename to be used when rendering the archive file
+
+----
+# filename to use for archive file
+archive.file=archive.html
+----
+
+==== Default feed output filename
+
+This option defines the output filename to be used when rendering the feed file
+
+----
+# filename to use for feed
+feed.file=feed.xml
+----
+
+==== Default sitemap output filename
+
+This option defines the output filename to be used when rendering the sitemap file
+
+----
+# filename to use for sitemap file
+sitemap.file=sitemap.xml
+----
+
+==== Default tag output directory
+
+This option defines the output directory to be used when rendering the tag files
+
+----
+# folder name to use for tag files
+tag.path=tags
+----
+
+==== Sanitize tag value
+
+This option defines whether the tag value should be santized before being used as a filename (i.e. replace spaces with hypens)
+
+----
+# sanitize tag value before it is used as filename (i.e. replace spaces with hyphens)
+tag.sanitize=false 
+----
+
+When this option is set to true it will mean a tag value of `west wing` will be changed to `west-wing`, the tag file generated will be `west-wing.html`.
+
+==== Default encoding when rendering
+
+This option defines the character encoding that should be used when rendering files
+
+----
+# character encoding MIME name used for rendering.
+# use one of http://www.iana.org/assignments/character-sets/character-sets.xhtml
+render.encoding=UTF-8
+---- 
+
+==== Default output file extension
+
+This option defines the default file extension that should be used when rendering content files
+
+----
+# file extension for output content files
+output.extension=.html
+----
+
+==== Default suffix for draft content
+
+This option defines the default suffix to be used when rendering draft content files
+
+----
+# draft content suffix
+draft.suffix=-draft
+----
+
+==== Default port for server mode
+
+This option defines the default port the server will listen on
+
+----
+# default server port
+server.port=8820
+----
+
+==== Default Freemarker project file
+
+This option defines the filename of the ZIP containing the example project that uses Freemarker templates
+
+----
+# zip file containing example project structure using freemarker templates
+example.project.freemarker=example_project_freemarker.zip
+----
+
+==== Default Groovy SimpleTemplateEngine project file
+
+This option defines the filename of the ZIP containing the example project that uses Groovy SimpleTemplateEngine templates
+
+----
+# zip file containing example project structure using groovy templates
+example.project.groovy=example_project_groovy.zip
+----
+
+==== Default Groovy MarkupTempateEngine project file
+
+This option defines the filename of the ZIP containing the example project that uses Groovy MarkupTemplateEngine templates
+
+----
+# zip file containing example project structure using groovy markup templates
+example.project.groovy-mte=example_project_groovy-mte.zip
+----
+
+==== Default Thymeleaf project file
+
+This option defines the filename of the ZIP containing the example project that uses Thymeleaf templates
+
+----
+# zip file containing example project structure using thymeleaf templates
+example.project.thymeleaf=example_project_thymeleaf.zip
+----
+
+==== Default Asciidoctor attributes
+
+This option defines a set of default Asciidoctor attributes that are used whenever AsciiDoc formatted content is rendered
+
+----
+# default asciidoctor options
+asciidoctor.attributes=source-highlighter=prettify
+----
+
+The value for this configuration option is a comma separated list of key-value pairs. The default value defines Prettify as the source highlighter to be used.
+
+==== Export JBake configuration to Asciidoctor content
+
+This option defines if the JBake configuration options should be exported to Asciidoctor as attributes so they are accessible from within AsciiDoc formatted content.
+
+----
+# should JBake config options be exported to Asciidoctor engine?
+asciidoctor.attributes.export=false
+----
+
+NOTE: By default this option is disabled in default.properties
+
+You can also define an additional prefix for the JBake configuration options, this is useful to avoid any collisions with existing AsciiDoc attributes
+
+----
+# prefix that should be used when JBake config options are exported
+asciidoctor.attributes.export.prefix=
+----
+
+NOTE: By default this option is disabled in default.properties
+
+==== Default Content Status
+
+This option defines a default status for content files, allowing you to avoid having to define the status value in each of your content files. This value is ONLY
+used if a status value hasn't been defined in the metadata header though.
+
+----
+# default status
+#default.status=published
+----
+
+NOTE: By default this option is disabled in default.properties
+
+==== Default date format for content files
+
+This option defines the default date format that is used when JBake tries to parse the date defined in the metadata header of content files.
+
+The format is specified using pattern letters, details of what is available can be found in the 
+https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html[Java API docs].
+
+----
+# default date format used in content files
+date.format=yyyy-MM-dd
+---- 
+
+==== Markdown extensions
+
+This option defines what Markdown extensions are enabled when content created in the Markdown format is rendered. Each extension required should be separated by a comma. 
+For details on what extensions are available please see the https://github.com/sirthias/pegdown[Pegdown docs].
+
+----
+# comma delimited default markdown extensions
+markdown.extensions=HARDWRAPS,AUTOLINKS,FENCED_CODE_BLOCKS,DEFINITIONS
+----
+
+You can use the alias `ALL` to enable all available extensions. You can also disable specific extensions by prefixing the extension name with a hyphen:
+
+----
+# comma delimited default markdown extensions
+markdown.extensions=ALL,-HARDWRAPS
+----
+
+==== Markdown parsing timeout
+
+This option defines the parsing timeout value in milliseconds for the Pegdown parser that is used for Markdown format support. This value limits the time spent 
+parsing each piece of Markdown content.
+
+----
+# millis to parse single markdown page. See PegDown Parse configuration for details
+markdown.maxParsingTimeInMillis=2000
+----
+
+==== Persistent content store
+
+This option defines whether the content store built while parsing your content files is persisted to disk or not. When it is persisted to disk the next time you 
+perform a bake only those content files that have changed will be rendered speeding up the process. When it is not persisted to disk, i.e. kept in memory, a full bake 
+of all content is performed every time.
+
+----
+# database store (local, memory)
+db.store=memory
+----
+
+* local = content store is persisted to disk
+* memory = content store is held only in memory during bake
+
+==== Persistent content store path
+
+This option defines the directory that is used to persist the content store to disk. It is only relevant when the content store is persisted to disk.
+
+----
+# database path
+db.path=cache
+----
+
+==== Thymeleaf Locale
+
+This option defines the locale to be used when rendering Thymeleaf templates.
+
+----
+# thymeleaf locale
+thymeleaf.locale=en
+----
+
+==== Ignore hidden asset files
+
+This option defines whether hidden asset files should be ignored or not as part of the baking process. When set to `true` it means files such as `.DS_Store` or 
+`desktop.ini` won't be included in your baked output.
+
+----
+asset.ignore=false
+----
+
+==== Enable paging on index page
+
+This option enables paging on the index page output when set to `true`. To be used in conjunction with the next option.
+
+----
+index.paginate=false
+----
+
+==== Posts per page
+
+This option defines how many posts will be output on each index page.
+
+----
+index.posts_per_page=10
+----
+
+==== Enable extensionless URI's
+
+This option enables extensionless URI's, so instead of /blog/2014/03/26/post.html JBake will output to /blog/2014/03/26/post/index.html allowing you to 
+refer to the URI without an extension. 
+
+----
+uri.noExtension=false
+----
+
+NOTE: Requires the following option to be set to define a prefix.
+
+==== Enable extensionless URI's prefix
+
+This option defines the prefix to apply extensionless URI's for.
+
+----
+uri.noExtension.prefix=/blog/
+----
+
+=== Custom configuration options
+
+You can also define additional options in your `jbake.properties` file for use in your project, especially in your template files. A great example is provided in the 
+sample projects that have an option called `site.host` which defines the host URL for the site:
+
+----
+site.host=http://jbake.org
+----
+
+This custom option is then used from within the feed template like so:
+
+----
+...
+<title><#escape x as x?xml>${post.title}</#escape></title>
+<link>${config.site_host}/${post.uri}</link>
+<pubDate>${post.date?string("EEE, d MMM yyyy HH:mm:ss Z")}</pubDate>
+...
+----
+
+To provide an absolute URI for use in a link.

--- a/content/docs/2.5.1/content-files.ad
+++ b/content/docs/2.5.1/content-files.ad
@@ -1,0 +1,103 @@
+= Content Files
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Content Files
+
+=== Metadata Header
+
+The metadata header defines some basic information that JBake uses when baking the content file.
+
+Each raw HTML or Markdown content file *must* have a metadata header in it which looks like this:
+
+----
+title=Weekly Links #2
+date=2013-02-01
+type=post
+tags=weekly links, java
+status=published
+~~~~~~
+----
+
+In the header you *must* have at least the **status** & **type** fields, the rest are optional. The only exception to this rule is if 
+you define a default status in your link:#configuration[configuration] file.
+
+If you leave the **date** field out then the files last modified timestamp will be used instead.
+
+For an AsciiDoc formatted content file the metadata header section is optional, the JBake metadata can be defined in the AsciiDoc document header itself like so:
+
+----
+= Project Structure
+Jonathan Bullock
+2013-10-17
+:jbake-type: page
+:jbake-tags: documentation, manual
+:jbake-status: published
+----
+
+NOTE: JBake related attributes included in the AsciiDoc header require the `jbake-` prefix to avoid any collisions.
+
+==== Status
+
+You have 3 options for the status field:
+
+* `draft` - drafts are rendered the same as published content however they are given a "-draft" suffix, for example `first-post-draft.html`, but not included in any published collections
+* `published`  - published content is rendered and included in the published collections
+* `published-date` - providing content date is equal to or past current date content will be considered published and included in the published collections
+
+==== Type
+
+You can choose what template file your content file will be mixed with by changing the value of the `type` field. By default there are 2 standard types:
+
+* `type=post` will mean the content file will be mixed with the template: post.ftl
+* `type=page` will mean the content file will be mixed with the template: page.ftl
+
+You can also define more types in your project configuration to give you more flexibility in your project, for details of this please see <<custom_templates>>.
+
+==== Custom Metadata
+
+You can also define custom metadata in the header that can be exposed to the templates, for example:
+
+----
+summary=This is a summary of the larger post
+----
+
+And access it in the templates like so:
+
+----
+<p>${content.summary}</p>
+----
+
+This feature is extremely useful when you want to control the rendering of extra market in the templates such as https://disqus.com/[Disqus] for comments 
+on certain posts/pages or to display images using some JavaScript library like https://jquery.com/[jQuery].
+
+==== Complex Custom Metadata
+
+If you need to define a complex structure of metadata you can use JSON format to achieve this, here's an example:
+
+----
+type=page
+og={"description": "Something"}
+----
+
+WARNING: The JSON content must be contained within a single line and cannot span multiple lines.
+
+This complex data is then accessible from the templates like this:
+
+----
+<#if content?? && content.og??> <1>
+	<meta property="og:description" content="${content.og.description}"/> <2>
+</#if>
+----
+
+<1> Checks the `content` map is not null and that the `content.og` map is not null
+<2> Outputs the `description` value from the `content.og` map
+
+=== Content Body
+
+Everything after the metadata header is considered the content body and made available to the templates, after being converted to HTML if required in the case of 
+Markdown or AsciiDoc.

--- a/content/docs/2.5.1/data-variables.ad
+++ b/content/docs/2.5.1/data-variables.ad
@@ -1,0 +1,64 @@
+= Data Variables
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Data Model
+
+A data model is exposed to each of the templates (regardless of what template engine you use) allowing you to get access to the data parsed from within 
+the content files, the model can also be used to apply logic to the output from the templates.
+
+=== Global
+
+These data variables are available to all templates regardless.
+
+- `version` = version of JBake being used
+- `published_date` = date baking took place
+- `[type]s` = collection of all content of [type] (e.g. posts = all content of type=post or snippets = all content of type=snippet)
+- `published_content` = collection of all published content (regardless of the type)
+- `published_posts` = collection of just published posts in date descending order
+- `published_pages` = collection of just published pages in date descending order
+- `all_content` = collection of all content (regardless of type)
+- `alltags` = collection of all tags used across all published content
+- `content.rootpath` = path to root of project (to be used for relative path to assets)
+- `config.[option]` = map of configuration data
+
+All the configuration options are available with any `.` in the property being replaced with `_`.
+For example `template.index.file=index.ftl` is available via `config.template_index_file`.
+
+In your templates you can loop through any of the collections above in the templates, and access a map of values for each element like so: `content.[value]` 
+all of the metadata header fields are available such as `content.title` along with the body of the content file `content.body`.
+
+=== Page / Post / Custom
+
+These predefined templates as well as any custom templates you create yourself have the following data available to them:
+
+- `content.[value]` = map of file contents
+
+All of the metadata header fields are available such as `content.title` and the body of the file is available via `content.body`.
+
+In the map you also have access to:
+
+- `content.file` = the full path to the source file
+- `content.uri` = the URI for the baked file
+
+=== Index
+
+This predefined template has the following extra data variables available to it related to paging:
+
+- `nextFileName` = if this variable exists it provides the filename of the next page
+- `previousFileName` = if this variable exists it provides the filename of the previous page
+
+These variables allow you provide next and previous links in your template to navigate through the pages.
+
+NOTE: As indicated, these variables may not exist so you should check first before referring to it.
+
+=== Tags
+
+This predefined template has the following extra data available to it:
+
+- `tag` = tag being rendered
+- `tag_posts` = collection of published posts for tag in date descending order

--- a/content/docs/2.5.1/data-variables.ad
+++ b/content/docs/2.5.1/data-variables.ad
@@ -51,6 +51,8 @@ This predefined template has the following extra data variables available to it 
 
 - `nextFileName` = if this variable exists it provides the filename of the next page
 - `previousFileName` = if this variable exists it provides the filename of the previous page
+- `numberOfPages` = if this variable exists it provides the total number of pages (_since 2.5.1_)
+- `currentPageNumber` = if this variable exists it provides the current number of the page (_since 2.5.1_)
 
 These variables allow you provide next and previous links in your template to navigate through the pages.
 

--- a/content/docs/2.5.1/index.ad
+++ b/content/docs/2.5.1/index.ad
@@ -1,0 +1,34 @@
+= Documentation v2.5.0
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+:numbered:
+:sectanchors:
+:icons: font
+:toc:
+:toc-placement!:
+
+toc::[]
+
+include::installation.ad[lines=9..1000]
+
+include::quickstart-guide.ad[lines=9..1000]
+
+include::usage.ad[lines=9..1000]
+
+include::project-structure.ad[lines=9..1000]
+
+include::content-files.ad[lines=9..1000]
+
+include::template.ad[lines=9..1000]
+
+include::data-variables.ad[lines=9..1000]
+
+include::configuration.ad[lines=9..1000]
+
+include::use-as-library.ad[lines=9..1000]
+
+include::build-tool-integration.ad[lines=9..1000]

--- a/content/docs/2.5.1/installation.ad
+++ b/content/docs/2.5.1/installation.ad
@@ -1,0 +1,46 @@
+= Installation
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Installation
+
+=== Prerequisites
+
+The only prerequisite for JBake is that you have a http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java 6+ JRE] installed and that 
+the `java` command is available in your path.
+
+=== Binary Distribution
+
+. link:/download.html[Download] the main binary distribution and unzip JBake into a folder on your hard disk, this folder will be known as `JBAKE_HOME`
+. Add a entry for `JBAKE_HOME/bin` to your path environment variable
+. Open a command prompt and run `jbake -h` (or `jbake.bat -h` if you are on Windows) to confirm everything works, you should see usage help text
+
+----
+JBake v2.5.0 (2016-10-03 17:56) [http://jbake.org]
+
+Usage: jbake ...
+----
+
+=== SDKMAN
+
+You can also install JBake via http://sdkman.io//[SDKMAN] (Software Development Kit Manager - formerly known as GVM) if you are running a Bash based platform (Mac OSX, Unix, Linux, Cygwin or Solaris etc.).
+SDKMAN will take care of downloading the latest distribution, installing it and configuring your environment for you. 
+
+After you have SDKMAN installed enter the following command to install the latest version of JBake:
+
+----
+$ sdk install jbake
+----
+
+=== Homebrew
+
+You can also install JBake via http://brew.sh/[Homebrew] if you are running OS X. After you have installed Homebrew enter the following command to install the 
+latest version of JBake:
+
+----
+$ brew install jbake
+----

--- a/content/docs/2.5.1/project-structure.ad
+++ b/content/docs/2.5.1/project-structure.ad
@@ -1,0 +1,89 @@
+= Project Structure
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Project Structure
+
+Here is an example source directory structure for a project:
+
+----
+.
+|-- assets
+|   |-- favicon.gif
+|   |-- robots.txt
+|   |-- img
+|   |   |-- logo.png
+|   |-- js
+|   |   |-- custom.js
+|   |-- css
+|       |-- style.css
+|
+|-- content
+|   |-- about.html
+|   |-- 2013
+|       |-- 01
+|       |   |-- hello-world.html
+|       |-- 02 
+|           |-- weekly-links-1.ad
+|           |-- weekly-links-2.md
+|
+|-- templates
+|   |-- index.ftl
+|   |-- page.ftl
+|   |-- post.ftl
+|   |-- feed.ftl
+|
+|-- jbake.properties
+----
+
+=== Assets Directory
+
+The assets directory is where you should place your static files such as images, CSS files and JavaScript files etc. These files are copied over to the 
+baked output as is. You can create any directory structure you like in the assets directory and this structure will be maintained when copied.
+
+=== Content Directory
+
+The content directory is where your content files should be placed, these files will be "mixed" with the templates to generate the baked output. Again 
+you can create any directory structure you like for your content, this structure will be maintained when the baked output is created.
+
+The extension of the content file determines what type of content it contains:
+
+* `.html` = raw HTML content
+* `.md` = http://daringfireball.net/projects/markdown/syntax[Markdown] formatted content
+* `.ad` = http://www.methods.co.nz/asciidoc/[AsciiDoc] formatted content
+* `.adoc` = http://www.methods.co.nz/asciidoc/[AsciiDoc] formatted content
+* `.asciidoc` = http://www.methods.co.nz/asciidoc/[AsciiDoc] formatted content
+
+NOTE: JBake uses http://pegdown.org[Pegdown] to support Markdown format and http://asciidoctor.org/[Asciidoctor] to support AsciiDoc format.
+
+=== Templates Directory
+
+The templates directory is where your templates files go, these files are "mixed" with your content files to generate the baked output. You should place your 
+templates into the root of this directory.
+
+The extension of the template file determines the template engine:
+
+* `.ftl` = http://freemarker.org[Freemarker]
+* `.gsp` = http://www.groovy-lang.org/[Groovy's SimpleTemplateEngine]
+* `.groovy` = http://www.groovy-lang.org/[Groovy's SimpleTemplateEngine]
+* `.gxml` = http://www.groovy-lang.org/[Groovy's XmlTemplateEngine]
+* `.tpl` = http://www.groovy-lang.org/[Groovy's MarkupTemplateEngine]
+* `.thyme` = http://www.thymeleaf.org/[Thymeleaf] 
+* `.html` = http://www.thymeleaf.org/[Thymeleaf]
+* `.jade` = https://github.com/neuland/jade4j[Jade]
+
+
+It is recommended that you don't mix different template types, try to stick to just 1 type of templates in your project.
+
+For more information on what you can do in each template engine have a look at the example templates provided with JBake and their 
+respective documentation: http://freemarker.org/docs/index.html[Freemarker], http://docs.groovy-lang.org/latest/html/documentation/template-engines.html[Groovy], 
+http://www.thymeleaf.org/doc/html/Using-Thymeleaf.html[Thymeleaf] & https://github.com/neuland/jade4j[Jade].
+
+=== Project Configuration
+
+Your project specific configuration is held within the `jbake.properties` file which should be located in the root directory of the project. This file controls 
+how your project is baked.

--- a/content/docs/2.5.1/quickstart-guide.ad
+++ b/content/docs/2.5.1/quickstart-guide.ad
@@ -1,0 +1,73 @@
+= Quickstart Guide
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Quickstart Guide
+
+=== Setup
+
+First link:/download.html[download JBake] and follow the <<installation>> instructions. After that open a command prompt and run the following command to make 
+sure everything is working:
+
+----
+jbake -h
+----
+
+You should then see the following output:
+
+----
+JBake v2.5.0 (2015-05-30 17:56) [http://jbake.org]
+
+Usage: jbake ...
+----
+
+=== Create a Project
+
+To get up and running quickly with JBake you can use it's example project structure along with sample templates as a starting point for you project or site. To do so 
+first you will need to create a new directory and change into it:
+
+----
+$ mkdir project
+$ cd project
+----
+
+Then you can use JBake to initialise this directory with it's example project structure and templates by executing the following command:
+
+----
+$ jbake -i
+----
+
+NOTE: This will use http://freemarker.org[Freemarker] templates by default, see the <<usage>> section on how to specify the template engine you prefer.
+
+=== Bake
+
+Once you have added some real content to your project and customised your templates you can bake your project by executing the following commands:	
+
+----
+$ cd project
+$ jbake -b
+----
+
+NOTE: This will place the baked project into a directory called `output` in the current directory by default.
+
+=== Preview
+
+You can then see what your baked project looks like immediately by running JBake in server mode:
+
+----
+$ cd project
+$ jbake -s
+
+JBake v2.5.0 (2016-10-03 17:56) [http://jbake.org]
+
+Serving out contents of: [output] on http://localhost:8820/
+(To stop server hit CTRL-C)
+----
+
+You can then preview it in your browser at http://localhost:8820.
+
+That's all there is to it, you can go from nothing to a fully baked site in minutes.

--- a/content/docs/2.5.1/template.ad
+++ b/content/docs/2.5.1/template.ad
@@ -1,0 +1,66 @@
+= Templates
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Templates
+
+=== Default Templates
+
+There are default template files defined in JBake that are used to render a number of special pages that require no content files to be present, these are:
+
+* `index` - used to render an index.html file
+* `archive` - used to render an archive.html file
+* `feed` - used to render a feed.xml file
+* `tag` - used to render a HTML file for each tag used
+* `sitemap` - used to render a sitemap.xml file
+
+If you don't require any of these special pages to be rendered then you can turn off the rendering of them by adding the following lines to your 
+`jbake.properties` file:
+
+----
+...
+render.index=false
+render.archive=false
+render.feed=false
+render.tags=false
+render.sitemap=false
+...
+----
+
+There are also two default templates files defined in JBake that are used to render content files, these are:
+
+* `page` - used to render any content file marked with a type of 'page'
+* `post` - used to render any content file marked with a type of 'post'
+
+=== Custom Templates
+
+You also have the ability to define new custom templates that can be used when rendering different types of content files.
+
+First add the following line to your `jbake.properties` file:
+
+----
+...
+template.<customtype>.file=templateXYZ.ftl
+...
+----
+
+Then create your template file and place it into the 'templates' folder inside your project, after that you can create your content files making sure 
+that the metadata header has the following entry:
+
+----
+...
+type=<customtype>
+...
+----
+
+If you'd like the content files to be rendered with your custom template file using a different extension then add the following to your `jbake.properties` file:
+
+----
+...
+template.<customtype>.extension=.xml
+...
+----

--- a/content/docs/2.5.1/usage.ad
+++ b/content/docs/2.5.1/usage.ad
@@ -1,0 +1,125 @@
+= Usage
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Usage
+
+Running jbake without arguments is equivalent to running jbake with `-h`, and will display the usage instructions.
+
+----
+$ jbake
+----
+
+=== Bake command
+
+The bake command mixes your source content with your templates and cooks it all into a fully baked web site. You have a number of different ways to execute the bake 
+command to suite your requirements.
+
+The `-b` option without any parameters will assume your source content is in the current working directory and will place the baked output into a directory named `output` 
+in the current directory:
+
+----
+$ jbake -b
+----
+
+NOTE: JBake will create this `output` directory if it does not already exist.
+
+If you specify only the source directory as a parameter then the output directory will automatically be generated inside the source directory:
+
+----
+$ jbake -b <source>
+----
+
+You can also specify your source directory and output directory to enable you to have full control over the baking process:
+
+----
+$ jbake -b <source> <output>
+----
+
+You can even omit the `-b` option if you supply the source directory and output directory parameters:
+
+----
+$ jbake <source> <output>
+----
+
+
+=== Initialisation command
+
+The initialisation command will seed your project directory with the required project structure along with a number of sample content files and templates. You do have the 
+option to choose what template engine is used though.
+
+The `-i` option will seed the current working directory and use the http://freemarker.org[Freemarker] template engine by default:
+
+----
+$ jbake -i
+----
+
+You can also specify the directory to initialise by supplying an additional parameter:
+
+----
+$ jbake -i <directory>
+----
+
+To specify the template engine you can use the `-t` option along with another parameter:
+
+----
+$ jbake -i -t <freemarker|groovy|groovy-mte|thymeleaf|jade>
+----
+
+NOTE: The template engines available are http://freemarker.org[Freemarker], http://www.groovy-lang.org/[Groovy Simple and Markup], http://www.thymeleaf.org/[Thymeleaf] 
+and https://github.com/neuland/jade4j[Jade].
+
+==== Example Project Structures
+
+The example project structure and sample templates are stored in your JBake installation folder in the files:
+
+* `example_project_freemarker.zip`
+* `example_project_groovy.zip`
+* `example_project_groovy-mte.zip`
+* `example_project_thymeleaf.zip`
+* `example_project_jade.zip`
+
+If you'd like to change the structure or sample templates in some way then you can extract the contents of these files, update 
+as required, then ZIP them back up and replace the original ZIP file with your updated file. Then JBake will use your updated 
+project structure and templates when ever it initialises a new folder from then on.
+
+=== Server command
+
+The server command will allow you to see what your baked site looks like when served out by a HTTP web server, great for when you want to preview your site using 
+your local web browser.
+
+The `-s` option will start JBake in server mode allowing you to preview your baked site at http://localhost:8820/ by default it will serve out the contents of the 
+`output` directory in the current working directory:
+
+----
+$ jbake -s
+----
+
+NOTE: The local port used can be changed via the configuration file.
+
+You can specify the directory to serve out by supplying an additional parameter:
+
+----
+$ jbake -s <directory>
+----
+
+==== Watch mode
+
+While the server is running JBake will watch the content folder for any changes (new files as well as changes to existing content) and automatically trigger a bake. So 
+you can refresh your browser to see the changes to the output.
+
+This mode is best used in conjunction with incremental rendering, for details on how to enable this please see the <<persistent_content_store>> configuration option.
+
+=== Combining commands
+
+It is possible to combine certain JBake commands together like so:
+
+----
+$ jbake -b -s
+----
+
+This will bake your site first and then serve the output out using the built in server, using the defaults mentioned above.

--- a/content/docs/2.5.1/use-as-library.ad
+++ b/content/docs/2.5.1/use-as-library.ad
@@ -1,0 +1,129 @@
+= Use as Library
+Jonathan Bullock
+2016-10-03
+:jbake-type: page
+:jbake-tags: documentation
+:jbake-status: published
+:idprefix:
+
+== Use as Library
+
+JBake can be used as a library from other software systems allowing you to programmatically bake a site.
+
+=== Maven coordinates
+
+The main JBake artifact is available from the Maven Central repository, these are the coordinates:
+
+[source,xml]
+----
+<dependency>
+	<groupId>org.jbake</groupId>
+	<artifactId>jbake-core</artifactId>
+	<version>2.5.0</version>
+</dependency>
+----
+
+The 3rd party libraries that provide support for Markdown content or the Freemarker template engine etc. are defined as optional dependencies in `jbake-core` so if 
+you plan on using them you will have to include them as a dependency in your project as well.
+
+For Markdown content support add the following dependency:
+
+[source,xml]
+----
+<dependency>
+	<groupId>org.pegdown</groupId>
+	<artifactId>pegdown</artifactId>
+	<version>1.6.0</version>
+</dependency>
+----
+
+For AsciiDoc content support add the following dependency:
+
+[source,xml]
+----
+<dependency>
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>asciidoctorj</artifactId>
+	<version>1.5.4.1</version>
+</dependency>
+----
+
+For Freemarker template support add the following dependency:
+
+[source,xml]
+----
+<dependency>
+	<groupId>org.freemarker</groupId>
+	<artifactId>freemarker</artifactId>
+	<version>2.3.25-incubating</version>
+</dependency>
+----
+
+For Groovy template support add the following dependencies:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.codehaus.groovy</groupId>
+    <artifactId>groovy</artifactId>
+    <version>2.4.7</version>
+</dependency>
+<dependency>
+    <groupId>org.codehaus.groovy</groupId>
+    <artifactId>groovy-templates</artifactId>
+    <version>2.4.7</version>
+</dependency>
+----
+
+For Thymeleaf template support add the following dependencies:
+
+[source,xml]
+----
+<dependency>
+	<groupId>org.thymeleaf</groupId>
+	<artifactId>thymeleaf</artifactId>
+	<version>3.0.2.RELEASE</version>
+</dependency>
+----
+
+For Jade template support add the following dependencies:
+
+[source,xml]
+----
+<dependency>
+	<groupId>de.neuland-bfi</groupId>
+	<artifactId>jade4j</artifactId>
+	<version>1.2.3</version>
+</dependency>
+----
+
+=== API
+
+The main class you should be focusing on using is `Oven`, this class provides the main functionality via a `.bake()` method that requires some parameters to be 
+passed to it. Here's an example:
+
+[source, java, subs="attributes,verbatim"]
+----
+try {
+	File source = new File("/path/to/project_source"); //<1>
+	File destination = new File("/path/to/project_output"); //<2>
+	Oven oven = new Oven(source, destination, true); //<3>
+	oven.setupPaths(); //<4>
+	oven.bake(); //<5>
+} catch (JBakeException e) { //<6>
+	// do something with exception here
+}
+----
+
+<1> Defines the project source, this should be the root directory of the project, JBake will look in this directory for `jbake.properties`
+<2> Defines where the baked output should be placed
+<3> The third parameter defines if the local cache (persistent content store) should be cleared and therefore trigger a full bake
+<4> This method checks the paths supplied exist and content the required elements
+<5> This method performs the actual baking
+<6> If any exceptions are thrown during the path checks or baking they are wrapped in a JBakeException
+
+=== Logging
+
+All output is generated using LogBack apart from certain elements of the command line interface. You can control the output by making sure there is a logback.xml 
+on the classpath. The binary distribution includes a pre-defined https://github.com/jbake-org/jbake/blob/master/src/main/logging/logback.xml[logback.xml] that is 
+a good reference point.


### PR DESCRIPTION
Added a brief description of index pagination data model variables `numberOfPages` and `currentPageNumber`

By the way. I was a bit unsure where to add my changes. The 2.5.0 directory didn't seem right. So I created a copy of that directory and renamed it to the next target version 2.5.1.

How about adding the documentation into the jbake repository to generate and publish the documentation from there? 

Would be nice to integrate _improve this doc_ links like [grails user guide](http://docs.grails.org/latest/guide/introduction.html), too. What do you think?