### PR TITLE
Adding Guatemala Java Day conference site

### DIFF
--- a/content/community/sites.ad
+++ b/content/community/sites.ad
@@ -8,6 +8,7 @@ Jonathan Bullock
 
 To help others see what's possible with JBake add your JBake powered site to the list below by making a https://github.com/jbake-org/jbake.org/blob/master/content/community/sites.ad[pull request].
 
+* http://guate-jug.net/javaday2017[GuateJUG Java Day Conference] (https://github.com/guatejug/files/tree/master/JavaDay2017/site[source])
 * https://siddheshrane.github.io[Siddhesh Rane's blog] (https://github.com/SiddheshRane/blog[source]) (https://github.com/SiddheshRane/jbake-clean-blog-template[theme template])
 * https://andinoacara.com/[Andinoacara.com]
 * http://luisgc.github.io/blog/[Luiyología - LuisGC's blog] (https://github.com/luisgc/blog/[source])


### PR DESCRIPTION
Guatemala Java User group created an entire website for conference. Hence we want to showcase it in the JBake community.