### PR TITLE
Updated Release News for 2.6.0

### DIFF
--- a/content/news/jbake-v2-6-0-released.ad
+++ b/content/news/jbake-v2-6-0-released.ad
@@ -23,9 +23,11 @@ Here are a few of the major changes included in this release:
 * Added more data variables for use in templates when paging
 * AsciidoctorJ-Diagram is included in binary distribution (not declared as a dependency though) so you can include diagrams in your AsciiDoc content
 
+NOTE: If you are using pagination for the index page i.e. `index.paginate=true`, then please verify that you are using `published_posts` or equivalent `published_{contentType}` model instead of `posts` model. See this https://github.com/jbake-org/jbake/issues/389[bug fix^] for details.
+
 You can find the complete changelog for this release here: https://github.com/jbake-org/jbake/milestone/14?closed=1
 
-Thanks to everyone who has contributed something to this new release, and especially to https://github.com/ancho[Frank Becker] and https://github.com/manikmagar[Manik Magar] 
+Thanks to everyone who has contributed something to this new release, and especially to https://github.com/ancho[Frank Becker] and https://github.com/manikmagar[Manik Magar]
 who put a tremendous amount of work into this release. I'm also pleased to say they have recently joined the link:/community/team.html[JBake team].
 
 This release should also be available via Maven Central, SDKMAN and Homebrew in the next few days.


### PR DESCRIPTION
Added an explicit note in Release News about not using `posts` data model with index pagination. See [this group discussion](https://groups.google.com/d/msg/jbake-dev/j6U2lp2cZOM/w1IqoQ6gAQAJ) for how it can break pagination with 2.6.0