### PR TITLE
Fix broken link to ContentStore.java

### DIFF
--- a/content/docs/2.6.4/data-variables.adoc
+++ b/content/docs/2.6.4/data-variables.adoc
@@ -22,7 +22,7 @@ These data variables are available to all templates regardless.
 - `tags` = collection of all tags as `tag` data model. See <<Tag Data model>>.
 - `content.rootpath` = path to root of project (to be used for relative path to assets)
 - `config.[option]` = map of configuration data
-- `db` = alias for direct access to https://github.com/jbake-org/jbake/blob/master/src/main/java/org/jbake/app/ContentStore.java[ContentStore] class
+- `db` = alias for direct access to https://github.com/jbake-org/jbake/blob/master/jbake-core/src/main/java/org/jbake/app/ContentStore.java[ContentStore] class
 
 WARNING: The `db` variable provides direct access to the methods of the class which are subject to change without warning!
 


### PR DESCRIPTION
Should be: https://github.com/jbake-org/jbake/blob/master/jbake-core/src/main/java/org/jbake/app/ContentStore.java or https://github.com/jbake-org/jbake/blob/v2.6.4/jbake-core/src/main/java/org/jbake/app/ContentStore.java (perhaps this is better, but required to be update for each versions)