### PR TITLE
fix copyright year footer

### DIFF
--- a/templates/footer.ftl
+++ b/templates/footer.ftl
@@ -1,5 +1,5 @@
       <div class="footer">
-        <p>&copy; <a href="/community/team.html">JBake Team</a> 2012-2019 | <a href="/privacy.html">Privacy Policy</a> | Mixed with <a href="http://getbootstrap.com/">Bootstrap v2.3.1</a> | Baked with <a href="http://jbake.org">JBake ${version}</a></p>
+        <p>&copy; <a href="/community/team.html">JBake Team</a> 2012-<script>document.write(new Date().getFullYear());</script> | <a href="/privacy.html">Privacy Policy</a> | Mixed with <a href="http://getbootstrap.com/">Bootstrap v2.3.1</a> | Baked with <a href="http://jbake.org">JBake ${version}</a></p>
       </div>
 
     </div> <!-- /container -->


### PR DESCRIPTION
Update footer for copyright year. Result of this change in local run -  

<img width="809" alt="image" src="https://user-images.githubusercontent.com/877286/75155261-a4bf8f00-56dd-11ea-9aa5-9e3ddde3075e.png">
