### PR TITLE
Update mill link

### DIFF
--- a/content/docs/latest/build-tool-integration.adoc
+++ b/content/docs/latest/build-tool-integration.adoc
@@ -95,7 +95,7 @@ The plugin was originally created by http://melix.github.io/blog/[Cédric Champe
 
 == mill Plugin
 
-There is a https://www.lihaoyi.com/mill/[mill] plugin that integrates site generation with JBake into mill.
+There is a https://com-lihaoyi.github.io/mill/[mill] plugin that integrates site generation with JBake into mill.
 
 * https://github.com/lefou/mill-jbake[Plugin on GitHub]
 

--- a/content/docs/latest/build-tool-integration.adoc
+++ b/content/docs/latest/build-tool-integration.adoc
@@ -95,7 +95,7 @@ The plugin was originally created by http://melix.github.io/blog/[Cédric Champe
 
 == mill Plugin
 
-There is a https://com-lihaoyi.github.io/mill/[mill] plugin that integrates site generation with JBake into mill.
+There is a https://com-lihaoyi.github.io/mill/[Mill] plugin that integrates site generation with JBake into mill.
 
 * https://github.com/lefou/mill-jbake[Plugin on GitHub]
 


### PR DESCRIPTION
Link <https://www.lihaoyi.com/mill/> is no more valid, it seem it should be <https://com-lihaoyi.github.io/mill/> according to:
* https://github.com/lefou/mill-jbake where link to GitHub is given
* https://github.com/com-lihaoyi/mill where link to related website is given 