### PR TITLE
Trivia: Fix version mismatch in release notes of upcoming 2.7.0

### DIFF
--- a/content/news/jbake-v2.7.0-release-candidate.adoc
+++ b/content/news/jbake-v2.7.0-release-candidate.adoc
@@ -11,7 +11,7 @@ Jonathan Bullock
 
 We're getting close to the release of JBake v2.7.0, and given the scale of code changes that have been made recently we thought it was prudent to make a release candidate available.
 
-So JBake v2.7.0-rc.5 is now available from https://github.com/jbake-org/jbake/releases[GitHub Releases]
+So JBake v2.7.0-rc.6 is now available from https://github.com/jbake-org/jbake/releases[GitHub Releases]
 
 We'd be really grateful if you could try this release candidate out against any JBake sites/projects you have. If you encounter any issues please https://github.com/jbake-org/jbake/issues[let us know] so we can address them prior to the final release of v2.7.0
 


### PR DESCRIPTION
Trivia: fix inconsistency between available release versions - most current is rc6 instead of rc5 as mentioned in docs.