### PR TITLE
Fix version mismatch for current RC7 of v2.7.0

### DIFF
--- a/content/news/jbake-v2.7.0-release-candidate.adoc
+++ b/content/news/jbake-v2.7.0-release-candidate.adoc
@@ -11,13 +11,13 @@ Jonathan Bullock
 
 We're getting close to the release of JBake v2.7.0, and given the scale of code changes that have been made recently we thought it was prudent to make a release candidate available.
 
-So JBake v2.7.0-rc.6 is now available from https://github.com/jbake-org/jbake/releases[GitHub Releases]
+So JBake v2.7.0-rc.7 is now available from https://github.com/jbake-org/jbake/releases[GitHub Releases]
 
 We'd be really grateful if you could try this release candidate out against any JBake sites/projects you have. If you encounter any issues please https://github.com/jbake-org/jbake/issues[let us know] so we can address them prior to the final release of v2.7.0
 
 === Important changes
 
-==== JBake Maven Plugin (v2.7.0-rc.6 or higher)
+==== JBake Maven Plugin (v2.7.0-rc.7 or higher)
 
 The JBake Maven plugin version is now aligns to the JBake version
 and includes all optional JBake core dependencies.


### PR DESCRIPTION
As a new RC just came out: keep the homepage in sync.